### PR TITLE
Added option to scrape post IPs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -95,13 +95,13 @@ async function main(): Promise<void> {
     config.manualForumModuleIDs && config.manualForumModuleIDs.length > 0 ? forumModuleIDs.push(...config.manualForumModuleIDs) : {};
     if (forumModuleIDs.length === 0) {
         statusMessage(MessageType.Critical, 'No forum module IDs for site, skipping forum scraping...');
-    } else if (config.disabledModules?.forums) {
+    } else if (config.disabledModules?.forums === true) {
         statusMessage(MessageType.Critical, 'Forums module disabled, skipping forum scraping...');
     } else if (await isModuleScraped(database, 'forums')) {
         statusMessage(MessageType.Critical, 'Forums already scraped, skipping forum scraping...');
     } else {
         statusMessage(MessageType.Info, 'Scraping forums...');
-        await getForums(database, config.domain, sessionID, [...new Set(forumModuleIDs)]);
+        await getForums(database, config.domain, sessionID, siteAuth, [...new Set(forumModuleIDs)], config.disabledModules.forums);
         await insertRow(database, 'scrapers', 'forums', true);
         deleteFiles(['./target/recovery/forum_progress.json']);
         statusMessage(MessageType.Completion, 'Finished forum scraping');

--- a/src/interfaces/forum.ts
+++ b/src/interfaces/forum.ts
@@ -304,6 +304,7 @@ export interface Post {
     user_votes: string;
     user_posts: string;
     url: string;
+    post_user_ip: string | null;
 }
 type ForumTuple = [
     string, string, string, string, string, string, string, string, string, string,
@@ -328,7 +329,7 @@ export interface ThreadsDB extends Array<ThreadTuple[number]> {}
 
 type PostTuple = [
     string, string, string, string, string, string, string, string, string, string, string,
-    string, string, string, string|null, string, string, boolean, string, string, string
+    string, string, string, string|null, string, string, boolean, string, string, string, string|null
 ]
 
 export interface PostsDB extends Array<PostTuple[number]> {}

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -23,7 +23,9 @@ export interface Config {
     manualUserIDs?: string[];
     disabledModules: {
         html: boolean;
-        forums: boolean;
+        forums: boolean | {
+            postIPs: boolean;
+		};
         galleries: boolean;
         news: boolean;
         wikis: boolean;
@@ -79,7 +81,9 @@ const defaultConfig: Config = {
     manualUserIDs: [],
     disabledModules: {
         html: false,
-        forums: false,
+        forums: {
+            postIPs: true,
+		},
         galleries: false,
         news: false,
         wikis: false,

--- a/src/util/tables.ts
+++ b/src/util/tables.ts
@@ -261,6 +261,7 @@ export const tableSchemas: TableSchema[] = [
             'user_votes TEXT',
             'user_posts TEXT',
             'url TEXT',
+            'post_user_ip TEXT',
         ],
     },
 


### PR DESCRIPTION
Tested with old config versions to ensure its default value is correctly set to avoid scraping unless specified.

I just realized that I forgot to include code related to the adding of the column 'post_user_ip', so users will have to delete the table or adding the column manually, similar to 1818ef012a4d859f3d1fbf51f01f0fe16070be72.